### PR TITLE
Get the code to work on a raspberry pi

### DIFF
--- a/dealer.c
+++ b/dealer.c
@@ -1572,7 +1572,7 @@ int main (int argc, char **argv) {
 
   gettimeofday (&tvstart, (void *) 0);
 
-  while ((c = getopt (argc, argv, "023ehuvmqp:g:s:l:V")) != -1) {
+  while ((c = getopt (argc, argv, "023ehuvmqp:g:s:l:V")) != (char)EOF) {
     switch (c) {
       case '0':
       case '2':


### PR DESCRIPTION
Without this change, it would get into an infinite loop in the CLI options because `c` was 255 instead of -1. I don't see why these values are considered the same on my main computer but not my pi (if you're doing char comparison, 255 and -1 have identical bits, and if you're doing int comparison, a signed char should be extended from 255 to -1. Maybe on a pi chars are unsigned by default?), but in practice this was needed.