### PR TITLE
Typo

### DIFF
--- a/Manual/input.html
+++ b/Manual/input.html
@@ -103,7 +103,7 @@ denote.
        two other players.
        <p>
        An alternate form of predeal specification is
-       <A HREF="#suit"><b>(suit)(player)==1</b></A> (for example:
+       <A HREF="#suit"><b>(suit)(player)==number</b></A> (for example:
        <b>"spades(north)==1"</b> and
        variants thereof for different suits, compass positions, numbers); this
        will ensure that (player) gets exactly the number of spades specified,


### PR DESCRIPTION
The real change is on line 106 (changing "1" to "number" when defining predeal syntax), the rest is removing whitespace.